### PR TITLE
fixed: allow traction neumann conditions for darcy+tracer

### DIFF
--- a/Common/Darcy/Darcy.C
+++ b/Common/Darcy/Darcy.C
@@ -39,6 +39,7 @@ Darcy::Darcy (unsigned short int n, int torder) :
 {
   primsol.resize(1 + torder);
 
+  tflux = nullptr;
   vflux = bodyforce = nullptr;
   flux = source = nullptr;
   reacInt = nullptr;
@@ -58,6 +59,8 @@ double Darcy::getFlux (const Vec3& X, const Vec3& normal) const
     return (*flux)(X);
   else if (vflux)
     return (*vflux)(X)*normal;
+  else if (tflux)
+    return (*tflux)(X,normal)*normal;
   else
     return 0.0;
 }
@@ -156,7 +159,7 @@ bool Darcy::evalInt (LocalIntegral& elmInt, const FiniteElement& fe,
 bool Darcy::evalBou (LocalIntegral& elmInt, const FiniteElement& fe,
                      const Vec3& X, const Vec3& normal) const
 {
-  if (!flux && !vflux)
+  if (!flux && !vflux && !tflux)
   {
     std::cerr <<" *** Darcy::evalBou: No fluxes."<< std::endl;
     return false;

--- a/Common/Darcy/Darcy.h
+++ b/Common/Darcy/Darcy.h
@@ -24,6 +24,7 @@
 
 class RealFunc;
 class SIMbase;
+class TractionFunc;
 class VecFunc;
 
 
@@ -61,6 +62,8 @@ public:
   void setFlux(RealFunc* f) { flux = f; }
   //! \brief Defines a vectorial flux function.
   void setFlux(VecFunc* f) { vflux = f; }
+  //! \brief Defines a vectorial flux function.
+  void setFlux(TractionFunc* f) { tflux = f; }
 
   //! \brief Evaluates the boundary fluid flux (if any) at specified point.
   double getFlux(const Vec3& X, const Vec3& normal) const;
@@ -189,6 +192,7 @@ protected:
   VecFunc*  bodyforce;    //!< Body force function
   VecFunc*  vflux;        //!< Flux function
   RealFunc* flux;         //!< Flux function
+  TractionFunc* tflux;    //!< Flux traction function
   RealFunc* source;       //!< Source function
 
   DarcyMaterial* mat = nullptr; //!< Material parameters

--- a/Common/Darcy/SIMDarcy.C
+++ b/Common/Darcy/SIMDarcy.C
@@ -180,10 +180,13 @@ template<class Dim>
 bool SIMDarcy<Dim>::initNeumann (size_t propInd)
 {
   const auto sit = Dim::myScalars.find(propInd);
+  const auto tit = Dim::myTracs.find(propInd);
   const auto vit = Dim::myVectors.find(propInd);
 
   if (sit != Dim::myScalars.end())
     drc.setFlux(sit->second);
+  else if (tit != Dim::myTracs.end())
+    drc.setFlux(tit->second);
   else if (vit != Dim::myVectors.end())
     drc.setFlux(vit->second);
   else


### PR DESCRIPTION
Need to support a TractionFunction when we have a tracer field (and thus a non-scalar equation). Still only allows for neumann conditions on the pressure.