### PR TITLE
Use SIMadmin::msgLevel to control the output print

### DIFF
--- a/Common/Darcy/DarcyTransportCorr.C
+++ b/Common/Darcy/DarcyTransportCorr.C
@@ -42,13 +42,20 @@ DarcyTransportCorr::DarcyTransportCorr (unsigned short int n, unsigned char n2)
   alpha = beta = 1.0e6;
   eps   = 1.0e-6;
 
+  // A 3x3 non-symmetric block matrix has the following storage convention:
+  //     q l g
+  // q : 1 4 5
+  // l : 6 2 7
+  // g : 8 9 3
+
   qq = 1;
-  ql = n2 > 0 ? 3 : 0;
-  nM = n2 > 0 ? 5 : 3;
+  ql = n2 > 0 ?  4 : 0;
+  lg = n2 > 0 ?  7 : 0;
+  nM = n2 > 0 ? 10 : 3;
 
   Fq = 1;
-  Fl = n2 > 0 ? 2 : 0;
-  nV = 3;
+  Fl = n2 > 0 ?  2 : 0;
+  nV = n2 > 0 ?  4 : 3;
 }
 
 
@@ -117,13 +124,16 @@ LocalIntegral*
 DarcyTransportCorr::getLocalIntegral (const std::vector<size_t>& nen,
                                       size_t, bool) const
 {
-  BlockElmMats* result = new BlockElmMats(2,2);
+  BlockElmMats* result = new BlockElmMats(3,3);
 
   result->resize(nM, nV);
   result->redim(1, nen[0], nsd,  1);
   result->redim(2, nen[1], nf2, -2);
+  result->redim(3, 1,      nf2, -3);
   if (ql > 0)
     result->redimOffDiag(ql, -1);
+  if (lg > 0)
+    result->redimOffDiag(lg, 1);
   result->finalize();
 
   return result;
@@ -204,6 +214,9 @@ bool DarcyTransportCorr::evalIntMx (LocalIntegral& elmInt,
           elMat.A[ql](k,m) += (C*fe.grad(1)(j,d) + dC(d)*fe.basis(1)(j)) * N2dJ;
       }
   }
+
+  if (lg > 0)
+    EqualOrderOperators::Weak::ItgConstraint(elMat.A[lg], fe, 1.0, 2);
 
   EqualOrderOperators::Weak::Source(elMat.b[Fq], fe, q);
 

--- a/Common/Darcy/DarcyTransportCorr.C
+++ b/Common/Darcy/DarcyTransportCorr.C
@@ -39,6 +39,9 @@ DarcyTransportCorr::DarcyTransportCorr (unsigned short int n, unsigned char n2)
   npv = n;
   nf2 = n2;
 
+  alpha = beta = 1.0e6;
+  eps   = 1.0e-6;
+
   qq = 1;
   ql = n2 > 1 ? 4 : (n2 > 0 ? 3 : 0);
   qm = n2 > 1 ? 5 : 0;
@@ -242,6 +245,7 @@ bool DarcyTransportCorr::evalSol2 (Vector& s, const Vectors& eV,
   s[4] = (qh - this->evalSol(eV.front(),fe.N)).length();
   for (size_t i = 0; i < nsd; ++i)
     s[5+i] = qh[i];
+
   return true;
 }
 
@@ -296,10 +300,11 @@ double DarcyTransportCorr::residual (const Vec3& X) const
   const double C = (*observed_C)(X);
   const Vec3 q = (*input_q)(X);
   const Vec3 grad_C = observed_C->gradient(X);
+  const double dCdt = observed_C->timeDerivative(X);
   const Tensor grad_q = input_q->gradient(X);
   const double f = (*input_source)(X);
 
-  return f - (grad_q.trace()*C + q*grad_C);
+  return f - (dCdt + grad_q.trace()*C + q*grad_C);
 }
 
 
@@ -310,10 +315,11 @@ double DarcyTransportCorr::residual (const Vector& eV,
   const double  f   = (*input_source)(X);
   const double  C   = (*observed_C)(X);
   const Vec3   dCdX = observed_C->gradient(X);
+  const double dCdt = observed_C->timeDerivative(X);
   const Vec3    q   = this->evalSol(eV,N);
   const Tensor dqdX = this->evalGrd(eV,dNdX);
 
-  return f - (dqdX.trace()*C + q*dCdX);
+  return f - (dCdt + dqdX.trace()*C + q*dCdX);
 }
 
 

--- a/Common/Darcy/DarcyTransportCorr.C
+++ b/Common/Darcy/DarcyTransportCorr.C
@@ -43,14 +43,12 @@ DarcyTransportCorr::DarcyTransportCorr (unsigned short int n, unsigned char n2)
   eps   = 1.0e-6;
 
   qq = 1;
-  ql = n2 > 1 ? 4 : (n2 > 0 ? 3 : 0);
-  qm = n2 > 1 ? 5 : 0;
-  nM = n2 > 1 ? 10 : (n2 > 0 ? 5 : 3);
+  ql = n2 > 0 ? 3 : 0;
+  nM = n2 > 0 ? 5 : 3;
 
   Fq = 1;
   Fl = n2 > 0 ? 2 : 0;
-  Fm = n2 > 1 ? 3 : 0;
-  nV = n2 > 0 ? 2+n2 : 3;
+  nV = 3;
 }
 
 
@@ -119,16 +117,13 @@ LocalIntegral*
 DarcyTransportCorr::getLocalIntegral (const std::vector<size_t>& nen,
                                       size_t, bool) const
 {
-  BlockElmMats* result = new BlockElmMats(1+nf2,2);
+  BlockElmMats* result = new BlockElmMats(2,2);
 
   result->resize(nM, nV);
-  result->redim(1, nen[0], nsd);
-  for (size_t i = 0; i < nf2; i++)
-    result->redim(2+i, nen[1], 1, -2);
+  result->redim(1, nen[0], nsd,  1);
+  result->redim(2, nen[1], nf2, -2);
   if (ql > 0)
     result->redimOffDiag(ql, -1);
-  if (qm > 0)
-    result->redimOffDiag(qm, -1);
   result->finalize();
 
   return result;
@@ -191,26 +186,29 @@ bool DarcyTransportCorr::evalIntMx (LocalIntegral& elmInt,
 
   const double scale = 1.0;
 
-  if (qq > 0)
-    EqualOrderOperators::Weak::Mass(elMat.A[qq], fe, scale);
+  EqualOrderOperators::Weak::Mass(elMat.A[qq], fe, scale);
 
-  if (ql > 0)
-    for (size_t i = 1; i <= fe.basis(2).size(); ++i)
-      for (size_t j = 1; j <= fe.basis(1).size(); ++j)
-        for (unsigned short int d = 1; d <= nsd; ++d)
-          elMat.A[ql]((j-1)*nsd+d,i) += fe.grad(1)(j,d) * fe.basis(2)(i) * fe.detJxW;
+  for (size_t i = 1; i <= fe.basis(2).size(); ++i)
+  {
+    const double N2dJ = fe.basis(2)(i) * fe.detJxW;
 
-  if (qm > 0)
-    for (size_t i = 1; i <= fe.basis(2).size(); ++i)
-      for (size_t j = 1; j <= fe.basis(1).size(); ++j)
-        for (unsigned short int d = 1; d <= nsd; ++d)
-          elMat.A[qm]((j-1)*nsd+d,i) += (C*fe.grad(1)(j,d) + dC(d)*fe.basis(1)(j)) * fe.basis(2)(i) * fe.detJxW;
+    size_t k = 1;
+    size_t l = (i-1)*nf2 + 1;
+    size_t m = l + 1;
+    for (size_t j = 1; j <= fe.basis(1).size(); ++j)
+      for (unsigned short int d = 1; d <= nsd; ++d, ++k)
+      {
+        if (nf2 > 0)
+          elMat.A[ql](k,l) += fe.grad(1)(j,d) * N2dJ;
+        if (nf2 > 1)
+          elMat.A[ql](k,m) += (C*fe.grad(1)(j,d) + dC(d)*fe.basis(1)(j)) * N2dJ;
+      }
+  }
 
-  if (Fq > 0)
-    EqualOrderOperators::Weak::Source(elMat.b[Fq], fe, q);
+  EqualOrderOperators::Weak::Source(elMat.b[Fq], fe, q);
 
-  if (Fm > 0)
-    EqualOrderOperators::Weak::Source(elMat.b[Fm], fe, R-dCdt, 1, 2);
+  if (nf2 > 1)
+    EqualOrderOperators::Weak::Source(elMat.b[Fl], fe, R-dCdt, 2, 2);
 
   return true;
 }
@@ -250,7 +248,8 @@ bool DarcyTransportCorr::evalSol2 (Vector& s, const Vectors& eV,
 }
 
 
-std::string DarcyTransportCorr::getField1Name (size_t i, const char* prefix) const
+std::string DarcyTransportCorr::getField1Name (size_t i,
+                                               const char* prefix) const
 {
   if (i == 11)
     switch (nsd) {
@@ -278,7 +277,8 @@ std::string DarcyTransportCorr::getField1Name (size_t i, const char* prefix) con
 }
 
 
-std::string DarcyTransportCorr::getField2Name (size_t i, const char* prefix) const
+std::string DarcyTransportCorr::getField2Name (size_t i,
+                                               const char* prefix) const
 {
   const auto names3 = std::array {
     "observed_C",

--- a/Common/Darcy/DarcyTransportCorr.h
+++ b/Common/Darcy/DarcyTransportCorr.h
@@ -131,7 +131,7 @@ private:
 
   //! \cond Block_matrix_indices
   size_t nM, nV, nf2;
-  size_t qq, ql;
+  size_t qq, ql, lg;
   size_t Fq, Fl;
   //! \endcond
 };

--- a/Common/Darcy/DarcyTransportCorr.h
+++ b/Common/Darcy/DarcyTransportCorr.h
@@ -121,10 +121,11 @@ public:
                   const Vector& N, const Matrix& dNdX, const Vec3& X) const;
 
 private:
-  double alpha = 1.0e6;  //!< Mass penalty parameter
-  double beta  = 1.0e6;  //!< Transport penalty parameter
-  double eps   = 1.0e-6; //!< Division by zero tolerance in mass-term scaling
-  std::unique_ptr<VecFunc>  input_q;      //!< Input Darcy velocity
+  double alpha; //!< Mass penalty parameter
+  double beta;  //!< Transport penalty parameter
+  double eps;   //!< Division by zero tolerance in mass-term scaling
+
+  std::unique_ptr<VecFunc>  input_q;      //!< Input velocity
   std::unique_ptr<RealFunc> input_source; //!< Input source
   std::unique_ptr<RealFunc> observed_C;   //!< Observed tracer concentration
 

--- a/Common/Darcy/DarcyTransportCorr.h
+++ b/Common/Darcy/DarcyTransportCorr.h
@@ -131,8 +131,8 @@ private:
 
   //! \cond Block_matrix_indices
   size_t nM, nV, nf2;
-  size_t qq, ql, qm;
-  size_t Fq, Fl, Fm;
+  size_t qq, ql;
+  size_t Fq, Fl;
   //! \endcond
 };
 

--- a/Common/Darcy/SIMDarcy.C
+++ b/Common/Darcy/SIMDarcy.C
@@ -213,21 +213,20 @@ bool SIMDarcy<Dim>::saveStep (const TimeStep& tp, int& nBlock, bool newData)
   if (Dim::opt.format < 0 || (tp.step % Dim::opt.saveInc) > 0)
     return true;
 
-  int iDump = tp.step/Dim::opt.saveInc + (drc.getOrder() == 0 ? 1 : 0);
-  double param2 = drc.getOrder() == 0 ? iDump : tp.time.t;
+  const int iType = tp.multiSteps() ? 0 : 1;
+  const int iDump = iType == 0 ? tp.step/Dim::opt.saveInc : 1;
 
-  if (!newData)
-      return this->writeGlvStep(iDump,param2,drc.getOrder() == 0 ? 1 : 0);
+  if (newData)
+  {
+    // Write solution fields
+    if (!this->writeGlvS(*solVec,iDump,nBlock,tp.time.t))
+      return false;
 
-  // Write solution fields
-  if (!this->writeGlvS(*solVec,iDump,nBlock,tp.time.t))
-    return false;
+    if (!this->doProjection())
+      return false;
 
-  if (!this->doProjection())
-    return false;
-
-  if (!solVec->empty())  {
-    if (!Dim::opt.pSolOnly) {
+    if (!solVec->empty() && !Dim::opt.pSolOnly)
+    {
       Matrix tmp;
       if (!this->project(tmp,*solVec))
         return false;
@@ -240,14 +239,14 @@ bool SIMDarcy<Dim>::saveStep (const TimeStep& tp, int& nBlock, bool newData)
         if (!this->writeGlvP(proj[i++],iDump,nBlock,100,pit.second.c_str()))
           return false;
     }
+
+    // Write element norms
+    if (Dim::opt.saveNorms)
+      if (!this->writeGlvN(eNorm,iDump,nBlock))
+        return false;
   }
 
-  // Write element norms
-  if (Dim::opt.saveNorms)
-    if (!this->writeGlvN(eNorm,iDump,nBlock))
-      return false;
-
-  return this->writeGlvStep(iDump,param2,drc.getOrder() == 0 ? 1 : 0);
+  return this->writeGlvStep(iDump, iType == 1 ? iDump : tp.time.t, iType);
 }
 
 
@@ -444,8 +443,8 @@ void SIMDarcy<Dim>::printFinalNorms (const TimeStep& tp)
 
   // Print global norm summary to console
   this->printNorms(gNorm, 36);
-
 }
+
 
 template<class Dim>
 void SIMDarcy<Dim>::printNorms (const Vectors& gNorm, size_t w) const

--- a/Common/Darcy/SIMDarcy.C
+++ b/Common/Darcy/SIMDarcy.C
@@ -51,6 +51,9 @@ SIMDarcy<Dim>::SIMDarcy (Darcy& itg, const std::vector<unsigned char>& nf) :
   Dim::myProblem = &drc;
   Dim::myHeading = "Darcy solver";
   aCode[0] = aCode[1] = 0;
+
+  if (drc.getOrder() > 0) // transient problem
+    Dim::msgLevel = 1; // prints primary solution summary only
 }
 
 
@@ -71,10 +74,9 @@ bool SIMDarcy<Dim>::parse (const tinyxml2::XMLElement* elem)
   if (strcasecmp(elem->Value(),"darcy"))
     return this->Dim::parse(elem);
 
-  bool useCache;
-  if (utl::getAttribute(elem,"cache",useCache)) {
+  if (bool useCache = false; utl::getAttribute(elem,"cache",useCache)) {
     IFEM::cout << (useCache ? "\tEnabling" : "\tDisabling")
-               << " caching of element matrices.\n";
+               <<" caching of element matrices."<< std::endl;
     drc.lCache(useCache);
   }
 
@@ -103,23 +105,19 @@ bool SIMDarcy<Dim>::parse (const tinyxml2::XMLElement* elem)
         IFEM::cout <<"\tAnalytical solution: expression"<< std::endl;
       }
       // Define the analytical boundary traction field
-      int code = 0;
-      if (utl::getAttribute(child,"code",code) && code > 0) {
+      if (int code = 0; utl::getAttribute(child,"code",code))
         if (code > 0 && Dim::mySol->getScalarSecSol())
         {
           this->setPropertyType(code,Property::NEUMANN);
           Dim::myVectors[code] = Dim::mySol->getScalarSecSol();
           aCode[1] = code;
         }
-      }
     }
     else if (!strcasecmp(child->Value(),"subiterations")) {
-      IFEM::cout << "\tUsing sub-iterations";
+      IFEM::cout <<"\tUsing sub-iterations:";
       utl::getAttribute(child,"tol",cycleTol);
       utl::getAttribute(child,"max",maxCycle);
-      IFEM::cout <<"\n\t\ttol = "<< cycleTol;
-      IFEM::cout <<"\n\t\tmax = "<< maxCycle;
-      IFEM::cout << std::endl;
+      IFEM::cout <<" tol = "<< cycleTol <<" max = "<< maxCycle << std::endl;
     }
     else if (!Dim::myProblem->parse(child))
       this->Dim::parse(child);
@@ -131,16 +129,18 @@ bool SIMDarcy<Dim>::parse (const tinyxml2::XMLElement* elem)
 template<class Dim>
 bool SIMDarcy<Dim>::initNeumann (size_t propInd)
 {
-  const auto sit = Dim::myScalars.find(propInd);
-  const auto tit = Dim::myTracs.find(propInd);
-  const auto vit = Dim::myVectors.find(propInd);
-
-  if (sit != Dim::myScalars.end())
+  if (const auto sit = Dim::myScalars.find(propInd);
+      sit != Dim::myScalars.end())
     drc.setFlux(sit->second);
-  else if (tit != Dim::myTracs.end())
+
+  else if (const auto tit = Dim::myTracs.find(propInd);
+           tit != Dim::myTracs.end())
     drc.setFlux(tit->second);
-  else if (vit != Dim::myVectors.end())
+
+  else if (const auto vit = Dim::myVectors.find(propInd);
+           vit != Dim::myVectors.end())
     drc.setFlux(vit->second);
+
   else
     return false;
 
@@ -191,8 +191,8 @@ void SIMDarcy<Dim>::registerFields (DataExporter& exporter)
 
   exporter.registerField("u", "primary", DataExporter::SIM, results);
   exporter.setFieldValue("u", this, solVec,
-                       Dim::opt.project.empty() ? nullptr : &proj,
-                       (results & DataExporter::NORMS) ? &eNorm : nullptr);
+                         Dim::opt.project.empty() ? nullptr : &proj,
+                         Dim::opt.saveNorms ? &eNorm : nullptr);
 }
 
 
@@ -274,16 +274,18 @@ template<class Dim>
 bool SIMDarcy<Dim>::solveStep (const TimeStep& tp)
 {
   if (Dim::msgLevel >= 0 && tp.multiSteps())
-    IFEM::cout <<"\n  step = "<< tp.step
-               <<"  time = "<< tp.time.t << std::endl;
-
-  bool conv = false;
-  tp.iter = 0;
+    this->printStep(tp.step, tp.time);
 
   if (tp.step == drc.getOrder())
     this->initLHSbuffers();
 
-  while (!conv)
+  const int printSol = maxCycle > -1 || tp.multiSteps() ? 0 : Dim::msgLevel;
+  const int oldLevel = Dim::msgLevel;
+  if (maxCycle > -1)
+    Dim::msgLevel = 1; // suppress patch assembly loop log
+
+  bool newSolution = false;
+  for (tp.iter = 0; !newSolution; tp.iter++)
   {
     if (!this->setMode(SIM::DYNAMIC))
       return false;
@@ -293,10 +295,15 @@ bool SIMDarcy<Dim>::solveStep (const TimeStep& tp)
     if (!this->assembleSystem(tp.time, solution, newTangent))
       return false;
 
-    if (!this->solveSystem(solution.front(),maxCycle > -1 ? 0 : Dim::msgLevel-1,"pressure    "))
+    if (!this->solveSystem(solution.front()))
       return false;
 
-    if (maxCycle > -1) {
+    this->printSolutionSummary(solution.front(),printSol,nullptr,0);
+
+    if (maxCycle < 0)
+      newSolution = true;
+    else
+    {
       this->setMode(SIM::RHS_ONLY);
       this->updateDirichlet(tp.time.t,nullptr);
       this->assembleSystem(tp.time, solution);
@@ -304,29 +311,29 @@ bool SIMDarcy<Dim>::solveStep (const TimeStep& tp)
       this->extractLoadVec(linRes);
       double rConv = linRes.norm2();
 
-      IFEM::cout <<"  cycle "<< tp.iter <<": Res = "<< rConv << std::endl;
+      Dim::adm.cout <<"  cycle "<< tp.iter <<": Res = "<< rConv << std::endl;
       if (rConv < cycleTol)
-        conv = true;
-
-      if (tp.iter >= maxCycle) {
+        newSolution = true;
+      else if (tp.iter >= maxCycle) {
         std::cerr <<" *** SIMDarcy::solveStep: Did not converge in "
-                 << maxCycle <<" staggering cycles, bailing.."<< std::endl;
-        return false;
+                  << maxCycle <<" staggering cycles, bailing.."<< std::endl;
+        break;
       }
-    } else
-      conv = true;
+    }
 
     newTangent = tp.step < drc.getOrder() || !drc.lCache();
-    ++tp.iter;
   }
 
   if (maxCycle > -1)
-    this->printSolutionSummary(solution.front(), 0, nullptr, 0);
+  {
+    this->printSolutionSummary(solution.front(),printSol,nullptr,0);
+    Dim::msgLevel = oldLevel; // in case it is used by other SIM's
+  }
 
   if (!tp.multiSteps() && adNorm == DCY::NO_ADAP && !this->doProjection())
     return false;
 
-  return true;
+  return newSolution;
 }
 
 
@@ -346,30 +353,29 @@ void SIMDarcy<Dim>::printSolutionSummary (const Vector& solution,
                                           int printSol, const char*,
                                           std::streamsize outPrec)
 {
-  const size_t nf = this->getNoFields();
-  if (nf > 1) {
+  if (this->getNoFields() == 2)
+  {
     // Compute and print solution norms
-    std::vector<size_t> iMax(nf);
-    std::vector<double> dMax(nf);
-    double dNorm;
-    drc.getSolutionNorms(*this, solution, dNorm, dMax.data(), iMax.data());
+    size_t iMax[2];
+    double dMax[2];
+    double dNorm = this->solutionNorms(solution,dMax,iMax);
 
-    int oldPrec = this->adm.cout.precision();
+    int oldPrec = Dim::adm.cout.precision();
     if (outPrec > 0)
-      this->adm.cout << std::setprecision(outPrec);
+      Dim::adm.cout << std::setprecision(outPrec);
 
-    this->adm.cout <<"  Primary solution summary: L2-norm         : ";
-    this->adm.cout << utl::trunc(dNorm);
-    this->adm.cout <<"\n                               Max pressure : ";
-    this->adm.cout << dMax[0] <<" node "<< iMax[0];
-    this->adm.cout <<"\n                          Max concentration : ";
-    this->adm.cout << dMax[1] <<" node "<< iMax[1] << "\n";
+    Dim::adm.cout <<"  Primary solution summary: L2-norm      : "
+                  << utl::trunc(dNorm)
+                  <<"\n                            Max pressure : "
+                  << utl::trunc(dMax[0]) <<" node "<< iMax[0]
+                  <<"\n                       Max concentration : "
+                  << utl::trunc(dMax[1]) <<" node "<< iMax[1] << std::endl;
 
-    this->adm.cout << std::setprecision(oldPrec);
-  } else {
-    this->SIMbase::printSolutionSummary(solution, printSol,
-                                        "pressure    ", outPrec);
+    if (outPrec > 0)
+      Dim::adm.cout << std::setprecision(oldPrec);
   }
+  else
+    this->SIMbase::printSolutionSummary(solution,printSol,"pressure",outPrec);
 }
 
 

--- a/Common/Darcy/SIMDarcyAdvection.C
+++ b/Common/Darcy/SIMDarcyAdvection.C
@@ -40,6 +40,7 @@ SIMDarcyAdvection<Dim>::SIMDarcyAdvection (DarcyAdvection& itg) :
 {
   Dim::myProblem = &drc;
   Dim::myHeading = "Darcy advection solver";
+  Dim::msgLevel  = 1;
 }
 
 
@@ -57,15 +58,14 @@ bool SIMDarcyAdvection<Dim>::parse (const tinyxml2::XMLElement* elem)
   if (strcasecmp(elem->Value(),"darcyadvection"))
     return this->Dim::parse(elem);
 
-  bool useCache;
-  if (utl::getAttribute(elem,"cache",useCache)) {
+  if (bool useCache = false; utl::getAttribute(elem,"cache",useCache)) {
     IFEM::cout << (useCache ? "\tEnabling" : "\tDisabling")
-               << " caching of element matrices.\n";
+               <<" caching of element matrices."<< std::endl;
     drc.lCache(useCache);
   }
 
   const tinyxml2::XMLElement* child = elem->FirstChildElement();
-  for (; child; child = child->NextSiblingElement()) {
+  for (; child; child = child->NextSiblingElement())
     if (!strcasecmp(child->Value(), "materialdata")) {
       int code = this->parseMaterialSet(child,mVec.size());
       mVec.resize(mVec.size()+1);
@@ -80,7 +80,6 @@ bool SIMDarcyAdvection<Dim>::parse (const tinyxml2::XMLElement* elem)
     }
     else if (!Dim::myProblem->parse(child))
       this->Dim::parse(child);
-  }
 
   return true;
 }
@@ -136,7 +135,7 @@ bool SIMDarcyAdvection<Dim>::init ()
   if (mVec.size() == 1)
     drc.setMaterial(mVec.front());
 
-  return true;
+  return drc.getOrder() > 0;
 }
 
 
@@ -155,8 +154,10 @@ bool SIMDarcyAdvection<Dim>::solveStep (const TimeStep& tp)
   if (!this->assembleSystem(tp.time, solution, newTangent))
     return false;
 
-  if (!this->solveSystem(solution.front(),Dim::msgLevel-1,"concentration"))
+  if (!this->solveSystem(solution.front()))
     return false;
+
+  this->printSolutionSummary(solution.front(), 0, "concentration");
 
   newTangent = tp.step < drc.getOrder() || !drc.lCache();
 
@@ -167,10 +168,9 @@ bool SIMDarcyAdvection<Dim>::solveStep (const TimeStep& tp)
 template<class Dim>
 bool SIMDarcyAdvection<Dim>::advanceStep (TimeStep&)
 {
-  if (drc.getOrder() > 0) {
-    drc.advanceStep();
-    this->pushSolution();
-  }
+  drc.advanceStep();
+  this->pushSolution();
+
   return true;
 }
 
@@ -185,8 +185,6 @@ bool SIMDarcyAdvection<Dim>::initMaterial (size_t propInd)
 
   return true;
 }
-
-
 
 
 template<class Dim>

--- a/Common/Darcy/SIMDarcyTransportCorr.C
+++ b/Common/Darcy/SIMDarcyTransportCorr.C
@@ -19,7 +19,6 @@
 #include "IFEM.h"
 #include "IntegrandBase.h"
 #include "Profiler.h"
-#include "SIM1D.h"
 #include "SIM2D.h"
 #include "SIM3D.h"
 #include "SIMenums.h"
@@ -43,12 +42,12 @@ namespace
 
 
 template<class Dim>
-SIMDarcyTransportCorr<Dim>::
-SIMDarcyTransportCorr (IntegrandBase& itg,
-                       const std::vector<unsigned char>& nf) : Dim(nf)
+SIMDarcyTransportCorr<Dim>::SIMDarcyTransportCorr (IntegrandBase& itg,
+                                                   const CharVec& nf) : Dim(nf)
 {
   Dim::myProblem = &itg;
   Dim::myHeading = "Darcy transport correction solver";
+  Dim::lagMTOK = true; // can do multithreading with global Lagrange multipliers
 }
 
 
@@ -70,15 +69,14 @@ bool SIMDarcyTransportCorr<Dim>::parse (const tinyxml2::XMLElement* elem)
 
   const tinyxml2::XMLElement* child = elem->FirstChildElement();
   for (; child; child = child->NextSiblingElement())
-    if (!strcasecmp(child->Value(),"constrain_integrated_multiplier")) {
-      constrainIntegratedLag = true;
-      IFEM::cout << "\tConstraining integrated multiplier";
-    } else if (!strcasecmp(child->Value(), "anasol")) {
+    if (!strcasecmp(child->Value(),"anasol"))
+    {
       std::string type;
       utl::getAttribute(child,"type",type,true);
       if (type == "expression")
-        this->mySol = new DarcyTCorr(child);
-    } else if (!Dim::myProblem->parse(child))
+        Dim::mySol = new DarcyTCorr(child);
+    }
+    else if (!Dim::myProblem->parse(child))
       this->Dim::parse(child);
 
   return true;
@@ -88,11 +86,12 @@ bool SIMDarcyTransportCorr<Dim>::parse (const tinyxml2::XMLElement* elem)
 template<class Dim>
 bool SIMDarcyTransportCorr<Dim>::preprocessBeforeAsmInit (int& nnod)
 {
-  if (constrainIntegratedLag) {
+  if (this->mixedProblem())
+  {
     ++nnod;
     for (int p = 1; p <= this->getNoPatches(); ++p)
       if (int lp = this->getLocalPatchIndex(p); lp > 0)
-        this->getPatch(lp)->addGlobalLagrangeMultipliers({nnod}, 1);
+        this->getPatch(lp)->addGlobalLagrangeMultipliers({nnod},Dim::nf[1]);
   }
 
   return true;
@@ -102,8 +101,6 @@ bool SIMDarcyTransportCorr<Dim>::preprocessBeforeAsmInit (int& nnod)
 template<class Dim>
 void SIMDarcyTransportCorr<Dim>::preprocessA ()
 {
-  Dim::myInts.emplace(0,Dim::myProblem);
-
   for (Property& p : Dim::myProps)
     if (p.pcode == Property::DIRICHLET_ANASOL) {
       if (vCode == abs(p.pindx))
@@ -136,7 +133,8 @@ void SIMDarcyTransportCorr<Dim>::registerFields (DataExporter& exporter)
 
 
 template<class Dim>
-bool SIMDarcyTransportCorr<Dim>::saveModel (char* fileName, int& geoBlk, int& nBlock)
+bool SIMDarcyTransportCorr<Dim>::saveModel (char* fileName,
+                                            int& geoBlk, int& nBlock)
 {
   return Dim::opt.format < 0 ? true : this->writeGlvG(geoBlk,fileName);
 }
@@ -190,8 +188,9 @@ bool SIMDarcyTransportCorr<Dim>::advanceStep (TimeStep&)
 
 
 template<class Dim>
-void SIMDarcyTransportCorr<Dim>::
-printSolutionSummary (const Vector&, int, const char*, std::streamsize outPrec)
+void SIMDarcyTransportCorr<Dim>::printSolutionSummary (const Vector&, int,
+                                                       const char*,
+                                                       std::streamsize outPrec)
 {
   const size_t nsd = this->getNoSpaceDim();
 
@@ -238,6 +237,5 @@ printSolutionSummary (const Vector&, int, const char*, std::streamsize outPrec)
 
 // Instantiations for different dimensions.
 
-template class SIMDarcyTransportCorr<SIM1D>;
 template class SIMDarcyTransportCorr<SIM2D>;
 template class SIMDarcyTransportCorr<SIM3D>;

--- a/Common/Darcy/SIMDarcyTransportCorr.C
+++ b/Common/Darcy/SIMDarcyTransportCorr.C
@@ -148,22 +148,29 @@ bool SIMDarcyTransportCorr<Dim>::saveStep (const TimeStep& tp, int& nBlock)
   if (Dim::opt.format < 0 || (tp.step % Dim::opt.saveInc) > 0)
     return true;
 
+  const int iType = tp.multiSteps() ? 0 : 1;
+  const int iStep = iType == 0 ? tp.step/Dim::opt.saveInc : 1;
+
   // Write solution fields
-  if (!this->writeGlvS(qSol,1,nBlock,0.0,"Darcy velocity"))
+  if (!this->writeGlvS(qSol,iStep,nBlock,tp.time.t,"Darcy velocity"))
     return false;
 
   // Write element norms
   if (Dim::opt.saveNorms)
-    if (!this->writeGlvN(eNorm,1,nBlock))
+    if (!this->writeGlvN(eNorm,iStep,nBlock))
       return false;
 
-  return this->writeGlvStep(1, 0.0, 1);
+  return this->writeGlvStep(iStep, iType == 1 ? iStep : tp.time.t, iType);
 }
 
 
 template<class Dim>
-bool SIMDarcyTransportCorr<Dim>::solveStep (const TimeStep&)
+bool SIMDarcyTransportCorr<Dim>::solveStep (const TimeStep& tp)
 {
+  if (Dim::msgLevel >= 0 && tp.multiSteps())
+    IFEM::cout <<"\n  step = "<< tp.step
+               <<"  time = "<< tp.time.t << std::endl;
+
   if (!this->setMode(SIM::DYNAMIC))
     return false;
   if (!this->initDirichlet())
@@ -171,7 +178,14 @@ bool SIMDarcyTransportCorr<Dim>::solveStep (const TimeStep&)
   if (!this->assembleSystem())
     return false;
 
-  return this->solveSystem(qSol,Dim::msgLevel-1,"darcy velocity");
+  return this->solveSystem(qSol,Dim::msgLevel,"velocity");
+}
+
+
+template<class Dim>
+bool SIMDarcyTransportCorr<Dim>::advanceStep (TimeStep&)
+{
+  return true;
 }
 
 
@@ -195,8 +209,8 @@ printSolutionSummary (const Vector&, int, const char*, std::streamsize outPrec)
     char D = 'X';
     for (size_t d = 0; d < nsd; d++, D++)
       if (utl::trunc(dMax[d]) != 0.0)
-        str <<"\n               Max "<< char('X'+d)
-            <<"-Darcy velocity : "<< dMax[d] <<" node "<< iMax[d];
+        str <<"\n"<< std::string(20,' ') <<" Max "<< char('X'+d)
+            <<"-velocity : "<< dMax[d] <<" node "<< iMax[d];
   }
 
   this->setQuadratureRule(Dim::opt.nGauss[1]);
@@ -212,10 +226,10 @@ printSolutionSummary (const Vector&, int, const char*, std::streamsize outPrec)
     double divq = 100.0*gNorm.front()[6]/gNorm.front()[5];
 
     if (Dim::adm.getProcId() == 0)
-      str <<"\nL2(q - q^) / L2(q^) = "<< diff
-          <<"%\nL2(div q^) / L2(q^) = "<< divQ
-          <<"%\nL2(res q^) / L2(c*q^) = "<< resQ
-          <<"%\nL2(div q) / L2(q) = "<< divq
+      str << "\n  L2(q - q^) / L2(q^) = "<< diff
+          <<"%\n  L2(div q^) / L2(q^) = "<< divQ
+          <<"%\n  L2(res q^) / L2(c*q^) = "<< resQ
+          <<"%\n  L2(div q) / L2(q) = "<< divq
           <<"% "<< gNorm.front()[6] <<" "<< gNorm.front()[5];
   }
 

--- a/Common/Darcy/SIMDarcyTransportCorr.h
+++ b/Common/Darcy/SIMDarcyTransportCorr.h
@@ -60,9 +60,13 @@ public:
   bool saveStep(const TimeStep& tp, int& nBlock);
 
   //! \brief Computes the solution for the current time step.
+  //! \param[in] tp Time stepping parameters
   bool solveStep(const TimeStep& tp);
 
-  //! \brief Prints a summary of the calculated solution to std::cout.
+  //! \brief Advances the time stepping.
+  bool advanceStep(TimeStep&);
+
+  //! \brief Prints out a summary of the calculated solution.
   //! \param[in] outPrec Number of digits after the decimal point in norm print
   void printSolutionSummary(const Vector&, int, const char*,
                             std::streamsize outPrec) override;

--- a/Common/Darcy/SIMDarcyTransportCorr.h
+++ b/Common/Darcy/SIMDarcyTransportCorr.h
@@ -29,12 +29,13 @@ namespace tinyxml2 { class XMLElement; }
 template<class Dim>
 class SIMDarcyTransportCorr : public Dim
 {
+  using CharVec = std::vector<unsigned char>; //!< Convenience type alias
+
 public:
   //! \brief Constructor.
-  //! \param itg Integrand to use
-  //! \param nf Fields on each basis
-  SIMDarcyTransportCorr(IntegrandBase& itg,
-                        const std::vector<unsigned char>& nf);
+  //! \param itg The integrand to use
+  //! \param[in] nf Number of fields on each basis
+  SIMDarcyTransportCorr(IntegrandBase& itg, const CharVec& nf);
   //! \brief Destructor.
   ~SIMDarcyTransportCorr() override;
 
@@ -56,7 +57,7 @@ public:
 
   //! \brief Saves the converged results to VTF file of a given time step.
   //! \param[in] tp Time stepping parameters
-  //! \param[in] nBlock Running VTF block counter
+  //! \param nBlock Running VTF block counter (updated)
   bool saveStep(const TimeStep& tp, int& nBlock);
 
   //! \brief Computes the solution for the current time step.
@@ -71,17 +72,14 @@ public:
   void printSolutionSummary(const Vector&, int, const char*,
                             std::streamsize outPrec) override;
 
-  //! \brief Adds a global multiplier for the constraint.
-  //! \param nnod Number of nodes in model
+  //! \brief Adds two global multipliers for the constraints.
+  //! \param nnod Number of nodes in the model (updated)
   bool preprocessBeforeAsmInit(int& nnod) override;
 
   //! \brief Performs some pre-processing tasks on the FE model.
-  //! \details This method is reimplemented to couple the weak Dirichlet
-  //! integrand to the generic Neumann property codes.
   void preprocessA() override;
 
 protected:
-  bool constrainIntegratedLag = false; //!< Constrain integrated multiplier
   Vector qSol; //!< Solution vector
   Matrix eNorm; //!< Element norms
   int vCode = 0; //!< Velocity anasol code

--- a/DarcyArgs.C
+++ b/DarcyArgs.C
@@ -34,8 +34,9 @@ bool DarcyArgs::parseArg (const char* argv)
     mixed = 11;
   else if (strcmp(argv, "-Mixed") == 0)
     mixed = 12;
-  else if ((timeMethod = TimeIntegration::get(argv+1)) > TimeIntegration::NONE)
-    ;
+  else if (TimeIntegration::Method tm = TimeIntegration::get(argv+1);
+           tm > TimeIntegration::NONE)
+    timeMethod = tm;
   else
     return this->SIMargsBase::parseArg(argv);
 

--- a/Test/SimpleSquare.reg
+++ b/Test/SimpleSquare.reg
@@ -8,34 +8,34 @@ Number of nodes       81
 Number of dofs        81
 Number of constraints 32
 Number of unknowns    49
-  step = 1  time = 0.1
+  step=1  time=0.1
 L2-norm            : 0.00301396
 Max pressure       : 0.00635299
-  step = 2  time = 0.2
+  step=2  time=0.2
 L2-norm            : 0.00601919
 Max pressure       : 0.0126901
-  step = 3  time = 0.3
+  step=3  time=0.3
 L2-norm            : 0.00902152
 Max pressure       : 0.019021
-  step = 4  time = 0.4
+  step=4  time=0.4
 L2-norm            : 0.0120229
 Max pressure       : 0.0253498
-  step = 5  time = 0.5
+  step=5  time=0.5
 L2-norm            : 0.0150239
 Max pressure       : 0.0316779
-  step = 6  time = 0.6
+  step=6  time=0.6
 L2-norm            : 0.0180249
 Max pressure       : 0.0380057
-  step = 7  time = 0.7
+  step=7  time=0.7
 L2-norm            : 0.0210258
 Max pressure       : 0.0443334
-  step = 8  time = 0.8
+  step=8  time=0.8
 L2-norm            : 0.0240267
 Max pressure       : 0.0506611
-  step = 9  time = 0.9
+  step=9  time=0.9
 L2-norm            : 0.0270276
 Max pressure       : 0.0569889
-  step = 10  time = 1
+  step=10  time=1
 L2-norm            : 0.0300285
 Max pressure       : 0.0633166
   Time integration completed.

--- a/Test/SquareCorr-p1.reg
+++ b/Test/SquareCorr-p1.reg
@@ -26,11 +26,12 @@ Resolving Dirichlet boundary conditions
 	Constraining P1 E4 in direction(s) 12
  >>> SAM model summary <<<
 Number of elements    1024
-Number of nodes       5314
-Number of dofs        10628
+Number of nodes       5315
+Number of dofs        10630
 Number of D-dofs      8450
+Number of L-dofs      2
 Number of P-dofs      2178
-Number of unknowns    10116
+Number of unknowns    10118
 Solving Darcy transport correction problem
 Processing integrand associated with code 0
 Assembling interior matrix terms for P1

--- a/Test/SquareCorr-p1.reg
+++ b/Test/SquareCorr-p1.reg
@@ -37,9 +37,9 @@ Assembling interior matrix terms for P1
 Done.
 Solving the equation system ...
   Primary solution summary: L2-norm : 0.0869103
-               Max X-Darcy velocity : 0.193085
-               Max Y-Darcy velocity : 0.193085
-L2(q - q^) / L2(q^) = 0.0050893
-L2(div q^) / L2(q^) = 0.77639
-L2(res q^) / L2(c\*q^) = 0.073384
-L2(div q) / L2(q) = [1-9].*e-1.% [1-9].*e-1. 0.124419
+                     Max X-velocity : 0.193085
+                     Max Y-velocity : 0.193085
+  L2(q - q^) / L2(q^) = 0.0050893
+  L2(div q^) / L2(q^) = 0.77639
+  L2(res q^) / L2(c\*q^) = 0.073384
+  L2(div q) / L2(q) = [1-9].*e-1.% [1-9].*e-1. 0.124419

--- a/Test/SquareCorr-p2.reg
+++ b/Test/SquareCorr-p2.reg
@@ -38,9 +38,9 @@ Assembling interior matrix terms for P1
 Done.
 Solving the equation system ...
   Primary solution summary: L2-norm : 0.0833513
-               Max X-Darcy velocity : 0.193085
-               Max Y-Darcy velocity : 0.193085
-L2(q - q^) / L2(q^) = 0.0046901
-L2(div q^) / L2(q^) = 0.64343
-L2(res q^) / L2(c\*q^) = 0.068011
-L2(div q) / L2(q) = [1-9].*e-1.% [1-9].*e-1. 0.124419
+                     Max X-velocity : 0.193085
+                     Max Y-velocity : 0.193085
+  L2(q - q^) / L2(q^) = 0.0046901
+  L2(div q^) / L2(q^) = 0.64343
+  L2(res q^) / L2(c\*q^) = 0.068011
+  L2(div q) / L2(q) = [1-9].*e-1.% [1-9].*e-1. 0.124419

--- a/Test/Tracer-adap-concentration.reg
+++ b/Test/Tracer-adap-concentration.reg
@@ -5,10 +5,8 @@ LR-spline basis functions are used
 Including a tracer field.
 	Permeability: 1.0|1.0
 	Porosity: 1
-	Dispersivity: 1.0
-	Using sub-iterations
-		tol = 1e-10
-		max = 50
+	Dispersivity: 1
+	Using sub-iterations: tol = 1e-10 max = 50
 	Refinement percentage: 2 type=6 (eps = 1e-06)
 	Refinement scheme: 2
 Number of elements    64
@@ -17,9 +15,9 @@ Number of dofs        162
 Number of unknowns    98
  >>> Starting adaptive simulation based on exact errors (norm index 7) <<<
 Adaptive step 1
-  Primary solution summary: L2-norm         : 0.0300084
-                               Max pressure : 0.0632771
-                          Max concentration : 0.0632741
+  Primary solution summary: L2-norm      : 0.0300084
+                            Max pressure : 0.0632771
+                       Max concentration : 0.0632741
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.147897
   External energy |(h,p^h)|^0.5      : 0.147897
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.147892
@@ -47,9 +45,9 @@ Number of elements    100
 Number of nodes       109
 Number of dofs        218
 Number of unknowns    154
-  Primary solution summary: L2-norm         : 0.0390323
-                               Max pressure : 0.0627608
-                          Max concentration : 0.0627582
+  Primary solution summary: L2-norm      : 0.0390323
+                            Max pressure : 0.0627608
+                       Max concentration : 0.0627582
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.148144
   External energy |(h,p^h)|^0.5      : 0.148144
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.14814
@@ -77,9 +75,9 @@ Number of elements    160
 Number of nodes       165
 Number of dofs        330
 Number of unknowns    266
-  Primary solution summary: L2-norm         : 0.0397259
-                               Max pressure : 0.0627106
-                          Max concentration : 0.0627091
+  Primary solution summary: L2-norm      : 0.0397259
+                            Max pressure : 0.0627106
+                       Max concentration : 0.0627091
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.148478
   External energy |(h,p^h)|^0.5      : 0.148478
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.148475

--- a/Test/Tracer-adap-pressure.reg
+++ b/Test/Tracer-adap-pressure.reg
@@ -5,10 +5,8 @@ LR-spline basis functions are used
 Including a tracer field.
 	Permeability: 1.0|1.0
 	Porosity: 1
-	Dispersivity: 1.0
-	Using sub-iterations
-		tol = 1e-10
-		max = 50
+	Dispersivity: 1
+	Using sub-iterations: tol = 1e-10 max = 50
 	Refinement percentage: 2 type=6 (eps = 1e-06)
 	Refinement scheme: 2
 Number of elements    64
@@ -17,9 +15,9 @@ Number of dofs        162
 Number of unknowns    98
  >>> Starting adaptive simulation based on exact errors (norm index 5) <<<
 Adaptive step 1
-  Primary solution summary: L2-norm         : 0.0300084
-                               Max pressure : 0.0632771
-                          Max concentration : 0.0632741
+  Primary solution summary: L2-norm      : 0.0300084
+                            Max pressure : 0.0632771
+                       Max concentration : 0.0632741
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.147897
   External energy |(h,p^h)|^0.5      : 0.147897
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.147892
@@ -47,9 +45,9 @@ Number of elements    100
 Number of nodes       109
 Number of dofs        218
 Number of unknowns    154
-  Primary solution summary: L2-norm         : 0.0390323
-                               Max pressure : 0.0627608
-                          Max concentration : 0.0627582
+  Primary solution summary: L2-norm      : 0.0390323
+                            Max pressure : 0.0627608
+                       Max concentration : 0.0627582
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.148144
   External energy |(h,p^h)|^0.5      : 0.148144
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.14814
@@ -77,9 +75,9 @@ Number of elements    160
 Number of nodes       165
 Number of dofs        330
 Number of unknowns    266
-  Primary solution summary: L2-norm         : 0.0397259
-                               Max pressure : 0.0627106
-                          Max concentration : 0.0627091
+  Primary solution summary: L2-norm      : 0.0397259
+                            Max pressure : 0.0627106
+                       Max concentration : 0.0627091
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.148478
   External energy |(h,p^h)|^0.5      : 0.148478
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.148475

--- a/Test/Tracer-adap-recovery.reg
+++ b/Test/Tracer-adap-recovery.reg
@@ -5,10 +5,8 @@ LR-spline basis functions are used
 Including a tracer field.
 	Permeability: 1.0|1.0
 	Porosity: 1
-	Dispersivity: 1.0
-	Using sub-iterations
-		tol = 1e-10
-		max = 50
+	Dispersivity: 1
+	Using sub-iterations: tol = 1e-10 max = 50
 	Refinement percentage: 2 type=6 (eps = 1e-06)
 	Refinement scheme: 2
 Number of elements    64
@@ -18,9 +16,9 @@ Number of unknowns    98
  >>> Starting adaptive simulation based on
      Continuous global L2-projection error estimates (norm group 1) <<<
 Adaptive step 1
-  Primary solution summary: L2-norm         : 0.0300084
-                               Max pressure : 0.0632771
-                          Max concentration : 0.0632741
+  Primary solution summary: L2-norm      : 0.0300084
+                            Max pressure : 0.0632771
+                       Max concentration : 0.0632741
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.147897
   External energy |(h,p^h)|^0.5      : 0.147897
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.147892
@@ -51,9 +49,9 @@ Number of elements    100
 Number of nodes       109
 Number of dofs        218
 Number of unknowns    154
-  Primary solution summary: L2-norm         : 0.0390323
-                               Max pressure : 0.0627608
-                          Max concentration : 0.0627582
+  Primary solution summary: L2-norm      : 0.0390323
+                            Max pressure : 0.0627608
+                       Max concentration : 0.0627582
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.148144
   External energy |(h,p^h)|^0.5      : 0.148144
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.14814
@@ -84,9 +82,9 @@ Number of elements    160
 Number of nodes       165
 Number of dofs        330
 Number of unknowns    266
-  Primary solution summary: L2-norm         : 0.0397259
-                               Max pressure : 0.0627106
-                          Max concentration : 0.0627091
+  Primary solution summary: L2-norm      : 0.0397259
+                            Max pressure : 0.0627106
+                       Max concentration : 0.0627091
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.148478
   External energy |(h,p^h)|^0.5      : 0.148478
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.148475

--- a/Test/Tracer-adap-recovery_conc.reg
+++ b/Test/Tracer-adap-recovery_conc.reg
@@ -5,10 +5,8 @@ LR-spline basis functions are used
 Including a tracer field.
 	Permeability: 1.0|1.0
 	Porosity: 1
-	Dispersivity: 1.0
-	Using sub-iterations
-		tol = 1e-10
-		max = 50
+	Dispersivity: 1
+	Using sub-iterations: tol = 1e-10 max = 50
 	Refinement percentage: 2 type=6 (eps = 1e-06)
 	Refinement scheme: 2
 Number of elements    64
@@ -18,9 +16,9 @@ Number of unknowns    98
  >>> Starting adaptive simulation based on
      Continuous global L2-projection error estimates (norm group 1) <<<
 Adaptive step 1
-  Primary solution summary: L2-norm         : 0.0300084
-                               Max pressure : 0.0632771
-                          Max concentration : 0.0632741
+  Primary solution summary: L2-norm      : 0.0300084
+                            Max pressure : 0.0632771
+                       Max concentration : 0.0632741
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.147897
   External energy |(h,p^h)|^0.5      : 0.147897
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.147892
@@ -51,9 +49,9 @@ Number of elements    100
 Number of nodes       109
 Number of dofs        218
 Number of unknowns    154
-  Primary solution summary: L2-norm         : 0.0390323
-                               Max pressure : 0.0627608
-                          Max concentration : 0.0627582
+  Primary solution summary: L2-norm      : 0.0390323
+                            Max pressure : 0.0627608
+                       Max concentration : 0.0627582
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.148144
   External energy |(h,p^h)|^0.5      : 0.148144
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.14814
@@ -84,9 +82,9 @@ Number of elements    160
 Number of nodes       165
 Number of dofs        330
 Number of unknowns    266
-  Primary solution summary: L2-norm         : 0.0397259
-                               Max pressure : 0.0627106
-                          Max concentration : 0.0627091
+  Primary solution summary: L2-norm      : 0.0397259
+                            Max pressure : 0.0627106
+                       Max concentration : 0.0627091
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.148478
   External energy |(h,p^h)|^0.5      : 0.148478
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.148475

--- a/Test/Tracer-adap-recovery_press.reg
+++ b/Test/Tracer-adap-recovery_press.reg
@@ -5,10 +5,8 @@ LR-spline basis functions are used
 Including a tracer field.
 	Permeability: 1.0|1.0
 	Porosity: 1
-	Dispersivity: 1.0
-	Using sub-iterations
-		tol = 1e-10
-		max = 50
+	Dispersivity: 1
+	Using sub-iterations: tol = 1e-10 max = 50
 	Refinement percentage: 2 type=6 (eps = 1e-06)
 	Refinement scheme: 2
 Number of elements    64
@@ -18,9 +16,9 @@ Number of unknowns    98
  >>> Starting adaptive simulation based on
      Continuous global L2-projection error estimates (norm group 1) <<<
 Adaptive step 1
-  Primary solution summary: L2-norm         : 0.0300084
-                               Max pressure : 0.0632771
-                          Max concentration : 0.0632741
+  Primary solution summary: L2-norm      : 0.0300084
+                            Max pressure : 0.0632771
+                       Max concentration : 0.0632741
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.147897
   External energy |(h,p^h)|^0.5      : 0.147897
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.147892
@@ -51,9 +49,9 @@ Number of elements    100
 Number of nodes       109
 Number of dofs        218
 Number of unknowns    154
-  Primary solution summary: L2-norm         : 0.0390323
-                               Max pressure : 0.0627608
-                          Max concentration : 0.0627582
+  Primary solution summary: L2-norm      : 0.0390323
+                            Max pressure : 0.0627608
+                       Max concentration : 0.0627582
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.148144
   External energy |(h,p^h)|^0.5      : 0.148144
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.14814
@@ -84,9 +82,9 @@ Number of elements    160
 Number of nodes       165
 Number of dofs        330
 Number of unknowns    266
-  Primary solution summary: L2-norm         : 0.0397259
-                               Max pressure : 0.0627106
-                          Max concentration : 0.0627091
+  Primary solution summary: L2-norm      : 0.0397259
+                            Max pressure : 0.0627106
+                       Max concentration : 0.0627091
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.148478
   External energy |(h,p^h)|^0.5      : 0.148478
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.148475

--- a/Test/Tracer-adap-total.reg
+++ b/Test/Tracer-adap-total.reg
@@ -5,10 +5,8 @@ LR-spline basis functions are used
 Including a tracer field.
 	Permeability: 1.0|1.0
 	Porosity: 1
-	Dispersivity: 1.0
-	Using sub-iterations
-		tol = 1e-10
-		max = 50
+	Dispersivity: 1
+	Using sub-iterations: tol = 1e-10 max = 50
 	Refinement percentage: 2 type=6 (eps = 1e-06)
 	Refinement scheme: 2
 Number of elements    64
@@ -17,9 +15,9 @@ Number of dofs        162
 Number of unknowns    98
  >>> Starting adaptive simulation based on exact errors (norm index 8) <<<
 Adaptive step 1
-  Primary solution summary: L2-norm         : 0.0300084
-                               Max pressure : 0.0632771
-                          Max concentration : 0.0632741
+  Primary solution summary: L2-norm      : 0.0300084
+                            Max pressure : 0.0632771
+                       Max concentration : 0.0632741
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.147897
   External energy |(h,p^h)|^0.5      : 0.147897
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.147892
@@ -47,9 +45,9 @@ Number of elements    100
 Number of nodes       109
 Number of dofs        218
 Number of unknowns    154
-  Primary solution summary: L2-norm         : 0.0390323
-                               Max pressure : 0.0627608
-                          Max concentration : 0.0627582
+  Primary solution summary: L2-norm      : 0.0390323
+                            Max pressure : 0.0627608
+                       Max concentration : 0.0627582
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.148144
   External energy |(h,p^h)|^0.5      : 0.148144
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.14814
@@ -77,9 +75,9 @@ Number of elements    160
 Number of nodes       165
 Number of dofs        330
 Number of unknowns    266
-  Primary solution summary: L2-norm         : 0.0397259
-                               Max pressure : 0.0627106
-                          Max concentration : 0.0627091
+  Primary solution summary: L2-norm      : 0.0397259
+                            Max pressure : 0.0627106
+                       Max concentration : 0.0627091
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.148478
   External energy |(h,p^h)|^0.5      : 0.148478
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.148475

--- a/Test/Tracer-bdf2.reg
+++ b/Test/Tracer-bdf2.reg
@@ -7,46 +7,46 @@ Number of elements    64
 Number of nodes       100
 Number of dofs        200
 Number of unknowns    128
-  step = 1  time = 0.1
-  Primary solution summary: L2-norm         : 0.00276727
-                               Max pressure : 0.00623959
-                          Max concentration : 0.00623229
-  step = 2  time = 0.2
-  Primary solution summary: L2-norm         : 0.00550777
-                               Max pressure : 0.0124168
-                          Max concentration : 0.0124064
-  step = 3  time = 0.3
-  Primary solution summary: L2-norm         : 0.00819374
-                               Max pressure : 0.01847
-                          Max concentration : 0.018459
-  step = 4  time = 0.4
-  Primary solution summary: L2-norm         : 0.010798
-                               Max pressure : 0.0243386
-                          Max concentration : 0.0243279
-  step = 5  time = 0.5
-  Primary solution summary: L2-norm         : 0.0132944
-                               Max pressure : 0.0299641
-                          Max concentration : 0.0299538
-  step = 6  time = 0.6
-  Primary solution summary: L2-norm         : 0.015658
-                               Max pressure : 0.0352902
-                          Max concentration : 0.0352804
-  step = 7  time = 0.7
-  Primary solution summary: L2-norm         : 0.017865
-                               Max pressure : 0.0402636
-                          Max concentration : 0.0402545
-  step = 8  time = 0.8
-  Primary solution summary: L2-norm         : 0.0198936
-                               Max pressure : 0.0448348
-                          Max concentration : 0.0448263
-  step = 9  time = 0.9
-  Primary solution summary: L2-norm         : 0.0217234
-                               Max pressure : 0.0489579
-                          Max concentration : 0.0489502
-  step = 10  time = 1
-  Primary solution summary: L2-norm         : 0.0233362
-                               Max pressure : 0.0525919
-                          Max concentration : 0.052585
+  step=1  time=0.1
+  Primary solution summary: L2-norm      : 0.00276727
+                            Max pressure : 0.00623959
+                       Max concentration : 0.00623229
+  step=2  time=0.2
+  Primary solution summary: L2-norm      : 0.00550777
+                            Max pressure : 0.0124168
+                       Max concentration : 0.0124064
+  step=3  time=0.3
+  Primary solution summary: L2-norm      : 0.00819374
+                            Max pressure : 0.01847
+                       Max concentration : 0.018459
+  step=4  time=0.4
+  Primary solution summary: L2-norm      : 0.010798
+                            Max pressure : 0.0243386
+                       Max concentration : 0.0243279
+  step=5  time=0.5
+  Primary solution summary: L2-norm      : 0.0132944
+                            Max pressure : 0.0299641
+                       Max concentration : 0.0299538
+  step=6  time=0.6
+  Primary solution summary: L2-norm      : 0.015658
+                            Max pressure : 0.0352902
+                       Max concentration : 0.0352804
+  step=7  time=0.7
+  Primary solution summary: L2-norm      : 0.017865
+                            Max pressure : 0.0402636
+                       Max concentration : 0.0402545
+  step=8  time=0.8
+  Primary solution summary: L2-norm      : 0.0198936
+                            Max pressure : 0.0448348
+                       Max concentration : 0.0448263
+  step=9  time=0.9
+  Primary solution summary: L2-norm      : 0.0217234
+                            Max pressure : 0.0489579
+                       Max concentration : 0.0489502
+  step=10  time=1
+  Primary solution summary: L2-norm      : 0.0233362
+                            Max pressure : 0.0525919
+                       Max concentration : 0.052585
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.125439
   External energy |(h,p^h)|^0.5      : 0.125439
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.125423

--- a/Test/Tracer-be.reg
+++ b/Test/Tracer-be.reg
@@ -7,46 +7,46 @@ Number of elements    64
 Number of nodes       100
 Number of dofs        200
 Number of unknowns    128
-  step = 1  time = 0.1
-  Primary solution summary: L2-norm         : 0.00276727
-                               Max pressure : 0.00623959
-                          Max concentration : 0.00623229
-  step = 2  time = 0.2
-  Primary solution summary: L2-norm         : 0.00550561
-                               Max pressure : 0.0124168
-                          Max concentration : 0.0123962
-  step = 3  time = 0.3
-  Primary solution summary: L2-norm         : 0.00818852
-                               Max pressure : 0.01847
-                          Max concentration : 0.0184343
-  step = 4  time = 0.4
-  Primary solution summary: L2-norm         : 0.0107895
-                               Max pressure : 0.0243386
-                          Max concentration : 0.0242875
-  step = 5  time = 0.5
-  Primary solution summary: L2-norm         : 0.0132826
-                               Max pressure : 0.0299641
-                          Max concentration : 0.029898
-  step = 6  time = 0.6
-  Primary solution summary: L2-norm         : 0.015643
-                               Max pressure : 0.0352902
-                          Max concentration : 0.0352096
-  step = 7  time = 0.7
-  Primary solution summary: L2-norm         : 0.0178471
-                               Max pressure : 0.0402636
-                          Max concentration : 0.0401696
-  step = 8  time = 0.8
-  Primary solution summary: L2-norm         : 0.0198729
-                               Max pressure : 0.0448348
-                          Max concentration : 0.0447281
-  step = 9  time = 0.9
-  Primary solution summary: L2-norm         : 0.0217001
-                               Max pressure : 0.0489579
-                          Max concentration : 0.0488399
-  step = 10  time = 1
-  Primary solution summary: L2-norm         : 0.0233105
-                               Max pressure : 0.0525919
-                          Max concentration : 0.0524636
+  step=1  time=0.1
+  Primary solution summary: L2-norm      : 0.00276727
+                            Max pressure : 0.00623959
+                       Max concentration : 0.00623229
+  step=2  time=0.2
+  Primary solution summary: L2-norm      : 0.00550561
+                            Max pressure : 0.0124168
+                       Max concentration : 0.0123962
+  step=3  time=0.3
+  Primary solution summary: L2-norm      : 0.00818852
+                            Max pressure : 0.01847
+                       Max concentration : 0.0184343
+  step=4  time=0.4
+  Primary solution summary: L2-norm      : 0.0107895
+                            Max pressure : 0.0243386
+                       Max concentration : 0.0242875
+  step=5  time=0.5
+  Primary solution summary: L2-norm      : 0.0132826
+                            Max pressure : 0.0299641
+                       Max concentration : 0.029898
+  step=6  time=0.6
+  Primary solution summary: L2-norm      : 0.015643
+                            Max pressure : 0.0352902
+                       Max concentration : 0.0352096
+  step=7  time=0.7
+  Primary solution summary: L2-norm      : 0.0178471
+                            Max pressure : 0.0402636
+                       Max concentration : 0.0401696
+  step=8  time=0.8
+  Primary solution summary: L2-norm      : 0.0198729
+                            Max pressure : 0.0448348
+                       Max concentration : 0.0447281
+  step=9  time=0.9
+  Primary solution summary: L2-norm      : 0.0217001
+                            Max pressure : 0.0489579
+                       Max concentration : 0.0488399
+  step=10  time=1
+  Primary solution summary: L2-norm      : 0.0233105
+                            Max pressure : 0.0525919
+                       Max concentration : 0.0524636
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.125439
   External energy |(h,p^h)|^0.5      : 0.125439
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.125149

--- a/Test/Tracer-schedule.reg
+++ b/Test/Tracer-schedule.reg
@@ -15,41 +15,41 @@ Number of dofs        100
 Number of unknowns    64
 Solving Darcy advection problem
 ===============================
-  step = 1  time = 0.1
-L2-norm            : 0.0277344
-Max pressure       : 0.0625
-L2-norm            : 0.00273631
-Max concentration   : 0.00612666
+  step=1  time=0.1
+  L2-norm            : 0.0277344
+  Max pressure       : 0.0625
+  L2-norm            : 0.00273631
+  Max concentration  : 0.00612666
   step=2  time=0.2
-L2-norm            : 0.00546891
-Max concentration   : 0.0122485
+  L2-norm            : 0.00546891
+  Max concentration  : 0.0122485
   step=3  time=0.3
-L2-norm            : 0.00820651
-Max concentration   : 0.0183905
+  L2-norm            : 0.00820651
+  Max concentration  : 0.0183905
   step=4  time=0.4
-L2-norm            : 0.0109546
-Max concentration   : 0.0245663
+  L2-norm            : 0.0109546
+  Max concentration  : 0.0245663
 \* Scheduled pressure change at time 0.5, calculating new pressure matrix.
-  step = 5  time = 0.5
-L2-norm            : 0.0277344
-Max pressure       : 0.0625
-L2-norm            : 0.0137151
-Max concentration   : 0.0307802
+  step=5  time=0.5
+  L2-norm            : 0.0277344
+  Max pressure       : 0.0625
+  L2-norm            : 0.0137151
+  Max concentration  : 0.0307802
   step=6  time=0.6
-L2-norm            : 0.0164883
-Max concentration   : 0.037033
+  L2-norm            : 0.0164883
+  Max concentration  : 0.037033
   step=7  time=0.7
-L2-norm            : 0.0192741
-Max concentration   : 0.0433243
+  L2-norm            : 0.0192741
+  Max concentration  : 0.0433243
   step=8  time=0.8
-L2-norm            : 0.0220723
-Max concentration   : 0.049654
+  L2-norm            : 0.0220723
+  Max concentration  : 0.049654
   step=9  time=0.9
-L2-norm            : 0.024883
-Max concentration   : 0.056022
+  L2-norm            : 0.024883
+  Max concentration  : 0.056022
   step=10  time=1
-L2-norm            : 0.0277062
-Max concentration   : 0.0624281
+  L2-norm            : 0.0277062
+  Max concentration  : 0.0624281
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.149071
   External energy |(h,p^h)|^0.5      : 0.149071
   H1 norm |p| = a(p,p)^0.5           : 0.149071

--- a/Test/Tracer.reg
+++ b/Test/Tracer.reg
@@ -4,18 +4,15 @@ Input file: Tracer.xinp
 Including a tracer field.
 	Permeability: 1.0|1.0
 	Porosity: 1
-	Dispersivity: 1.0
-	Using sub-iterations
-		tol = 1e-10
-		max = 50
+	Dispersivity: 1
+	Using sub-iterations: tol = 1e-10 max = 50
 Number of elements    64
 Number of nodes       100
 Number of dofs        200
 Number of unknowns    128
-  Primary solution summary: L2-norm         : 0.0277344
-                               Max pressure : 0.0625
-                          Max concentration : 0.0625
-
+  Primary solution summary: L2-norm      : 0.0277344
+                            Max pressure : 0.0625
+                       Max concentration : 0.0625
   H1 norm |p^h| = a(p^h,p^h)^0.5     : 0.149071
   External energy |(h,p^h)|^0.5      : 0.149071
   H1 norm |c^h| = a(c^h,c^h)^0.5     : 0.149071

--- a/main_DarcyCorrection.C
+++ b/main_DarcyCorrection.C
@@ -18,7 +18,6 @@
 #include "ASMmxBase.h"
 #include "IFEM.h"
 #include "Profiler.h"
-#include "SIM1D.h"
 #include "SIM2D.h"
 #include "SIM3D.h"
 #include "SIMSolver.h"
@@ -136,7 +135,7 @@ int main (int argc, char** argv)
   {
     std::cout <<"usage: "<< argv[0]
               <<" <inputfile> [-dense|-spr|-superlu[<nt>]|-samg|-petsc]\n"
-              <<"       [-lag|-spec|-LR] [-1D|-2D] [-nGauss <n>] [-hdf5]\n"
+              <<"       [-lag|-spec|-LR] [-2D] [-nGauss <n>] [-hdf5]\n"
               <<"       [-vtf <format> [-nviz <nviz>] [-nu <nu>] [-nv <nv>]"
               <<" [-nw <nw>]]\n";
     return 0;
@@ -151,6 +150,7 @@ int main (int argc, char** argv)
     return runSimulator1<SIM3D>(infile,args);
   else if (args.dim == 2)
     return runSimulator1<SIM2D>(infile,args);
-  else
-    return runSimulator1<SIM1D>(infile,args);
+
+  std::cerr <<" *** Sorry, no 1D implementation."<< std::endl;
+  return 1;
 }

--- a/main_DarcyCorrection.C
+++ b/main_DarcyCorrection.C
@@ -15,7 +15,6 @@
 #include "DarcyArgs.h"
 #include "SIMDarcyTransportCorr.h"
 
-#include "ASMenums.h"
 #include "ASMmxBase.h"
 #include "IFEM.h"
 #include "Profiler.h"
@@ -31,7 +30,7 @@
   \param args Darcy arguments
 */
 
-template<class Dim>
+template<class Dim, template<class T> class Solver>
 int runSimulator(char* infile, const DarcyArgs& args)
 {
   if (args.mixed > 10)
@@ -44,7 +43,7 @@ int runSimulator(char* infile, const DarcyArgs& args)
 
   DarcyTransportCorr itg(Dim::dimension,args.mixed%10);
   SIMDarcyTransportCorr<Dim> darcy(itg,fields);
-  SIMSolverStat solver(darcy);
+  Solver solver(darcy);
 
   utl::profiler->start("Model input");
 
@@ -65,6 +64,23 @@ int runSimulator(char* infile, const DarcyArgs& args)
     solver.handleDataOutput(darcy.opt.hdf5,darcy.getProcessAdm());
 
   return solver.solveProblem(infile,"Solving Darcy transport correction problem");
+}
+
+
+/*!
+  \brief Choose a solver template and then launch a simulator.
+  \param infile The input file to parse
+  \param args Simulator arguments
+*/
+
+template<class Dim>
+int runSimulator1(char* infile, const DarcyArgs& args)
+{
+  if (args.timeMethod == TimeIntegration::NONE)
+    return runSimulator<Dim,SIMSolverStat>(infile,args);
+
+  Dim::msgLevel = 1;
+  return runSimulator<Dim,SIMSolver>(infile,args);
 }
 
 
@@ -91,7 +107,6 @@ int runSimulator(char* infile, const DarcyArgs& args)
   \arg -nw \a nw : Number of visualization points per knot-span in w-direction
   \arg -hdf5 : Write primary and projected secondary solution to HDF5 file
   \arg -2D : Use two-parametric simulation driver
-  \arg -adap : Use adaptive simulation driver with LR-splines discretization
 */
 
 int main (int argc, char** argv)
@@ -127,18 +142,15 @@ int main (int argc, char** argv)
     return 0;
   }
 
-  if (args.adap)
-    IFEM::getOptions().discretization = ASM::LRSpline;
-
   IFEM::cout <<"\nInput file: "<< infile;
   IFEM::getOptions().print(IFEM::cout) << std::endl;
 
   utl::profiler->stop("Initialization");
 
   if (args.dim == 3)
-    return runSimulator<SIM3D>(infile,args);
+    return runSimulator1<SIM3D>(infile,args);
   else if (args.dim == 2)
-    return runSimulator<SIM2D>(infile,args);
+    return runSimulator1<SIM2D>(infile,args);
   else
-    return runSimulator<SIM1D>(infile,args);
+    return runSimulator1<SIM1D>(infile,args);
 }


### PR DESCRIPTION
Sits on top of #77 and requires in addition OPM/IFEM#854.
Prettify/shorten the log print for transient/adaptive simulations.